### PR TITLE
bug:38627 testing changes to TDE server-side.

### DIFF
--- a/entity-services/src/test/java/com/marklogic/entityservices/tests/TestEntityTypeSPARQL.java
+++ b/entity-services/src/test/java/com/marklogic/entityservices/tests/TestEntityTypeSPARQL.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
@@ -67,6 +68,22 @@ public class TestEntityTypeSPARQL extends EntityServicesTestBase {
 		ArrayNode bindings = (ArrayNode) results.get("results").get("bindings");
 		assertEquals(1, bindings.size());
 		assertEquals("http://marklogic.com/entity-services#version", bindings.get(0).get("version").get("value").asText());
+		
+	}
+	
+	@Test
+	@Ignore
+	// This test will verify the results of bug 
+	public void testEntityServicesVocabulary() {
+		String entityServicesClasses = 
+				 "PREFIX es: <http://marklogic.com/entity-services#> "
+				+"ASK where {"
+				+ "es:EntityServicesDocument a rdfs:Class ."
+				+ "es:EntityType a rdfs:Class ."
+				+ "es:Property a rdfs:Class ."
+
+				+ "}";
+		assertTrue("All the classes exist", queryMgr.executeAsk(queryMgr.newQueryDefinition(entityServicesClasses)));
 		
 	}
 }

--- a/entity-services/src/test/java/com/marklogic/entityservices/tests/TestEntityTypes.java
+++ b/entity-services/src/test/java/com/marklogic/entityservices/tests/TestEntityTypes.java
@@ -304,7 +304,8 @@ public class TestEntityTypes extends EntityServicesTestBase {
         		logger.debug("Actual number of triples: " + actualTriples.size());
         		
         		
-        		// more debug
+        		/* The following commented out code was for debuging purposes and 
+        		   lingers for those who need to maintain on into the future. */
 //        		OutputStream os = new FileOutputStream(new File("/tmp/actual.ttl"));
 //        		RDFDataMgr.write(os, actualTriples, Lang.TURTLE);
 //        		os.close();
@@ -312,8 +313,9 @@ public class TestEntityTypes extends EntityServicesTestBase {
 //        		RDFDataMgr.write(os, expectedTriples, Lang.TURTLE);
 //        		os.close();
         		
-        		//RDFDataMgr.write(System.out, actualTriples, Lang.TURTLE);
-        		// what a great function for debugging:
+        		// RDFDataMgr.write(System.out, actualTriples, Lang.TURTLE);
+        		
+        		// A great class for debugging, Defference.
 //        		logger.debug("Difference, expected - actual");
 //        		Graph diff = new com.hp.hpl.jena.graph.compose.Difference(expectedTriples, actualTriples);
 //        		RDFDataMgr.write(System.out, diff, Lang.TURTLE);

--- a/entity-services/src/test/resources/triples-expected/Order-0.0.1.ttl
+++ b/entity-services/src/test/resources/triples-expected/Order-0.0.1.ttl
@@ -19,6 +19,7 @@ type:Order  a          es:EntityType ;
         es:version     "0.0.1" .
 
 order:orderDate  a   es:Property ;
+        a es:RequiredProperty ;
         es:datatype  xsd:date ;
         es:title     "orderDate" .
 
@@ -38,6 +39,8 @@ order:hasOrderDetails
         es:title  "hasOrderDetails" .
 
 order:orderId  a     es:Property ;
+        a es:PrimaryKey ;
+        a es:RequiredProperty ;
         es:datatype  xsd:string ;
         es:title     "orderId" .
 

--- a/entity-services/src/test/resources/triples-expected/Order-0.0.4.ttl
+++ b/entity-services/src/test/resources/triples-expected/Order-0.0.4.ttl
@@ -19,6 +19,7 @@ type:Order  a          es:EntityType ;
         es:version     "0.0.4" .
 
 order:orderDate  a   es:Property ;
+        a es:RequiredProperty ;
         es:datatype  xsd:date ;
         es:title     "orderDate" .
 
@@ -41,6 +42,8 @@ order:hasOrderDetails
 <http://marklogic.com/entity-services/test/Order-0.0.4/Order/hasOrderDetails/items> es:ref  type:OrderDetails .
 
 order:orderId  a     es:Property ;
+        a es:PrimaryKey ;
+        a es:RequiredProperty ;
         es:datatype  xsd:string ;
         es:title     "orderId" .
 

--- a/entity-services/src/test/resources/triples-expected/Person-0.0.2.ttl
+++ b/entity-services/src/test/resources/triples-expected/Person-0.0.2.ttl
@@ -20,6 +20,7 @@ type:Person a es:EntityType ;
         prop:friendOf ;
     es:primaryKey prop:id .
 prop:id a es:Property ;
+    a es:PrimaryKey ;
     es:title "id" ;
     es:datatype xs:string .
 prop:firstName a es:Property ;

--- a/entity-services/src/test/resources/triples-expected/SchemaCompleteEntityType-0.0.1.ttl
+++ b/entity-services/src/test/resources/triples-expected/SchemaCompleteEntityType-0.0.1.ttl
@@ -6,6 +6,7 @@
 
 order:shortKey
         a es:Property ;
+        a es:RangeIndexedProperty ;
         es:datatype xs:short ;
         es:title "shortKey" .
 
@@ -16,6 +17,8 @@ order:decimalKey
 
 order:stringKey
         a es:Property ;
+        a es:RangeIndexedProperty ;
+        a es:WordLexiconProperty ;
         es:datatype xs:string ;
         es:title "stringKey" .
 
@@ -29,6 +32,7 @@ type:OrderDetails
 
 order:iriKey
         a es:Property ;
+        a es:RangeIndexedProperty ;
         es:datatype <http://marklogic.com/semantics#iri> ;
         es:title "iriKey" .
 
@@ -44,26 +48,31 @@ order:floatKey
 
 order:integerKey
         a es:Property ;
+        a es:RangeIndexedProperty ;
         es:datatype xs:integer ;
         es:title "integerKey" .
 
 order:negativeIntegerKey
         a es:Property ;
+        a es:RangeIndexedProperty ;
         es:datatype xs:negativeInteger ;
         es:title "negativeIntegerKey" .
 
 order:nonNegativeIntegerKey
         a es:Property ;
+        a es:RangeIndexedProperty ;
         es:datatype xs:nonNegativeInteger ;
         es:title "nonNegativeIntegerKey" .
 
 order:positiveIntegerKey
         a es:Property ;
+        a es:RangeIndexedProperty ;
         es:datatype xs:positiveInteger ;
         es:title "positiveIntegerKey" .
 
 order:nonPositiveIntegerKey
         a es:Property ;
+        a es:RangeIndexedProperty ;
         es:datatype xs:nonPositiveInteger ;
         es:title "nonPositiveIntegerKey" .
 
@@ -86,6 +95,7 @@ type:SchemaCompleteEntityType
 
 order:byteKey
         a es:Property ;
+        a es:RangeIndexedProperty ;
         es:datatype xs:byte ;
         es:title "byteKey" .
 
@@ -127,6 +137,8 @@ order:hexBinaryKey
 
 order:orderId
         a es:Property ;
+        a es:PrimaryKey ;
+        a es:RequiredProperty ;
         es:datatype xs:string ;
         es:collation "http://marklogic.com/collation/" ;
         es:title "orderId" .
@@ -167,6 +179,7 @@ order:unsignedIntKey
 
 order:unsignedByteKey
         a es:Property ;
+        a es:RangeIndexedProperty ;
         es:datatype xs:unsignedByte ;
         es:title "unsignedByteKey" .
 
@@ -211,6 +224,7 @@ order:arrayStringKey
         
 order:unsignedShortKey
         a es:Property ;
+        a es:RangeIndexedProperty ;
         es:datatype xs:unsignedShort ;
         es:title "unsignedShortKey" .
 
@@ -221,11 +235,13 @@ order:timeKey
 
 order:anyURIKey
         a es:Property ;
+        a es:RangeIndexedProperty ;
         es:datatype xs:anyURI ;
         es:title "anyURIKey" .
 
 order:booleanKey
         a es:Property ;
+        a es:RangeIndexedProperty ;
         es:datatype xs:boolean ;
         es:title "booleanKey" .
 
@@ -241,6 +257,7 @@ order:durationKey
 
 order:dateKey
         a es:Property ;
+        a es:RequiredProperty ;
         es:datatype xs:date ;
         es:title "dateKey" .
 


### PR DESCRIPTION
This PR corresponds to a patch for TDE in the /Config directory.  Here is the patch that I'm ready to check in there:

```
diff --git a/src/Config/entity-types-json.tdex b/src/Config/entity-types-json.tdex
index 52fb453..947ac9b 100644
--- a/src/Config/entity-types-json.tdex
+++ b/src/Config/entity-types-json.tdex
@@ -137,6 +137,41 @@
                   <predicate><val>$PROP_PRIMARYKEY</val></predicate>
                   <object><val>sem:iri(concat($et-subject-iri, "/", .))</val></object>
                 </triple>
+                <triple>
+                  <subject><val>sem:iri(concat($et-subject-iri, "/", .))</val></subject>
+                  <predicate><val>$RDF_TYPE</val></predicate>
+                  <object><val>sem:iri(concat($ESN, "PrimaryKey"))</val></object>
+                </triple>
+            </triples>
+        </template>
+        <template>
+            <context>./required</context>
+            <triples>
+                <triple>
+                  <subject><val>sem:iri(concat($et-subject-iri, "/", .))</val></subject>
+                  <predicate><val>$RDF_TYPE</val></predicate>
+                  <object><val>sem:iri(concat($ESN, "RequiredProperty"))</val></object>
+                </triple>
+            </triples>
+        </template>
+        <template>
+            <context>./rangeIndex</context>
+            <triples>
+                <triple>
+                  <subject><val>sem:iri(concat($et-subject-iri, "/", .))</val></subject>
+                  <predicate><val>$RDF_TYPE</val></predicate>
+                  <object><val>sem:iri(concat($ESN, "RangeIndexedProperty"))</val></object>
+                </triple>
+            </triples>
+        </template>
+        <template>
+            <context>./wordLexicon</context>
+            <triples>
+                <triple>
+                  <subject><val>sem:iri(concat($et-subject-iri, "/", .))</val></subject>
+                  <predicate><val>$RDF_TYPE</val></predicate>
+                  <object><val>sem:iri(concat($ESN, "WordLexiconProperty"))</val></object>
+                </triple>
             </triples>
         </template>
         <template>
diff --git a/src/Config/entity-types-xml.tdex b/src/Config/entity-types-xml.tdex
index 817f4e5..2116e5f 100644
--- a/src/Config/entity-types-xml.tdex
+++ b/src/Config/entity-types-xml.tdex
@@ -15,6 +15,7 @@
         <!-- constants -->
         <var><name>ESN</name><val>"http://marklogic.com/entity-services#"</val></var>
         <var><name>RDF</name><val>"http://www.w3.org/1999/02/22-rdf-syntax-ns#"</val></var>
+        <var><name>RDF_TYPE</name><val>sem:iri(concat($RDF, "type"))</val></var>
         <var><name>PROP_VERSION</name><val>sem:iri(concat($ESN, 'version'))</val></var>
         <var><name>PROP_TITLE</name><val>sem:iri(concat($ESN, 'title'))</val></var>
         <var><name>PROP_DEFINITIONS</name><val>sem:iri(concat($ESN, 'definitions'))</val></var>
@@ -94,7 +95,7 @@
     <triples>
         <triple>
           <subject><val>$doc-subject-iri</val></subject>
-          <predicate><val>sem:iri(concat($RDF, "type"))</val></predicate>
+          <predicate><val>$RDF_TYPE</val></predicate>
           <object><val>sem:iri(concat($ESN, "EntityServicesDocument"))</val></object>
         </triple>
         <triple>
@@ -122,7 +123,7 @@
             <triples>
                 <triple>
                   <subject><val>$et-subject-iri</val></subject>
-                  <predicate><val>sem:iri(concat($RDF, "type"))</val></predicate>
+                  <predicate><val>$RDF_TYPE</val></predicate>
                   <object><val>sem:iri(concat($ESN, "EntityType"))</val></object>
                 </triple>
                 <triple>
@@ -150,6 +151,41 @@
                           <predicate><val>$PROP_PRIMARYKEY</val></predicate>
                           <object><val>sem:iri(concat($et-subject-iri, "/", .))</val></object>
                         </triple>
+                        <triple>
+                          <subject><val>sem:iri(concat($et-subject-iri, "/", .))</val></subject>
+                          <predicate><val>$RDF_TYPE</val></predicate>
+                          <object><val>sem:iri(concat($ESN, "PrimaryKey"))</val></object>
+                        </triple>
+                    </triples>
+                </template>
+                <template>
+                    <context>./es:required</context>
+                    <triples>
+                        <triple>
+                          <subject><val>sem:iri(concat($et-subject-iri, "/", .))</val></subject>
+                          <predicate><val>$RDF_TYPE</val></predicate>
+                          <object><val>sem:iri(concat($ESN, "RequiredProperty"))</val></object>
+                        </triple>
+                    </triples>
+                </template>
+                <template>
+                    <context>./es:range-index</context>
+                    <triples>
+                        <triple>
+                          <subject><val>sem:iri(concat($et-subject-iri, "/", .))</val></subject>
+                          <predicate><val>$RDF_TYPE</val></predicate>
+                          <object><val>sem:iri(concat($ESN, "RangeIndexedProperty"))</val></object>
+                        </triple>
+                    </triples>
+                </template>
+                <template>
+                    <context>./es:word-lexicon</context>
+                    <triples>
+                        <triple>
+                          <subject><val>sem:iri(concat($et-subject-iri, "/", .))</val></subject>
+                          <predicate><val>$RDF_TYPE</val></predicate>
+                          <object><val>sem:iri(concat($ESN, "WordLexiconProperty"))</val></object>
+                        </triple>
                     </triples>
                 </template>
                 <template>

```
