### PR TITLE
Duplicate schema element handling bug 39228

### DIFF
--- a/entity-services/src/test/java/com/marklogic/entityservices/tests/TestSchemaGeneration.java
+++ b/entity-services/src/test/java/com/marklogic/entityservices/tests/TestSchemaGeneration.java
@@ -77,7 +77,7 @@ public class TestSchemaGeneration extends EntityServicesTestBase {
 			logger.info("Generating schema: " + entityType);
 			StringHandle schema = new StringHandle();
 			try {
-				schema = evalOneResult("es:schema-generate( es:entity-type-from-node( fn:doc( '" + entityType + "')))",
+				schema = evalOneResult("es:entity-type-from-node( fn:doc( '" + entityType + "'))=>es:schema-generate()",
 						schema);
 			} catch (TestEvalException e) {
 				throw new RuntimeException(e);

--- a/entity-services/src/test/java/com/marklogic/entityservices/tests/TestSchemaGeneration.java
+++ b/entity-services/src/test/java/com/marklogic/entityservices/tests/TestSchemaGeneration.java
@@ -21,6 +21,9 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.marklogic.client.document.JSONDocumentManager;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.InputStreamHandle;
 import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.AfterClass;
@@ -32,6 +35,10 @@ import org.xml.sax.SAXException;
 import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.DOMHandle;
 import com.marklogic.client.io.StringHandle;
+
+import javax.xml.transform.TransformerException;
+
+import static org.junit.Assert.fail;
 
 /**
  * Tests the server-side function es:echema-generate($entity-type) as
@@ -51,6 +58,9 @@ public class TestSchemaGeneration extends EntityServicesTestBase {
 
 		docMgr = schemasClient.newXMLDocumentManager();
 		schemas = generateSchemas();
+		InputStream is = docMgr.getClass().getResourceAsStream("/entity-type-units/et-duplicate-prop.json");
+		JSONDocumentManager documentManager = client.newJSONDocumentManager();
+		documentManager.write("et-duplicate-prop.json", new InputStreamHandle(is).withFormat(Format.JSON));
 	}
 
 	private static void storeSchema(String entityTypeName, StringHandle schemaHandle) {
@@ -65,23 +75,29 @@ public class TestSchemaGeneration extends EntityServicesTestBase {
 		docMgr.delete(moduleName);
 	}
 
+	private static StringHandle generateSchema(String entityType) {
+		logger.info("Generating schema: " + entityType);
+		StringHandle schema = new StringHandle();
+		try {
+			schema = evalOneResult("es:entity-type-from-node( fn:doc( '" + entityType + "'))=>es:schema-generate()",
+					schema);
+		} catch (TestEvalException e) {
+			throw new RuntimeException(e);
+		}
+		return schema;
+	}
+
 	private static Map<String, StringHandle> generateSchemas() {
 		Map<String, StringHandle> map = new HashMap<String, StringHandle>();
 
 		for (String entityType : entityTypes) {
 			if (entityType.contains(".xml")) {
 				continue;
-			}
-			;
+			};
 
-			logger.info("Generating schema: " + entityType);
-			StringHandle schema = new StringHandle();
-			try {
-				schema = evalOneResult("es:entity-type-from-node( fn:doc( '" + entityType + "'))=>es:schema-generate()",
-						schema);
-			} catch (TestEvalException e) {
-				throw new RuntimeException(e);
-			}
+			StringHandle schema = generateSchema(entityType);
+
+
 			map.put(entityType, schema);
 		}
 		return map;
@@ -109,6 +125,27 @@ public class TestSchemaGeneration extends EntityServicesTestBase {
 			removeSchema(entityType);
 		}
 
+	}
+
+
+	@Test
+	public void verifyDuplicatePropertyComments() throws TestEvalException, TransformerException {
+		String entityType = "et-duplicate-prop.json";
+		StringHandle schema = generateSchema(entityType);
+		storeSchema("et-duplicate-prop.xml", schema);
+
+		String integerValidates = "<ETTwo><a>123</a></ETTwo>";
+		String stringShouldnt = "<ETTwo><a>asdf</a></ETTwo>";
+
+		DOMHandle validateResult = evalOneResult("validate strict { " + integerValidates + "}", new DOMHandle());
+        //debugOutput(validateResult.get());
+        try {
+            validateResult = evalOneResult("validate strict { " + stringShouldnt + "}", new DOMHandle());
+            fail("Should be a validation error here.");
+        } catch (TestEvalException e) {
+            //pass
+        }
+		removeSchema(entityType);
 	}
 
 	@AfterClass

--- a/entity-services/src/test/resources/entity-type-units/et-duplicate-prop.json
+++ b/entity-services/src/test/resources/entity-type-units/et-duplicate-prop.json
@@ -1,0 +1,36 @@
+{
+  "info": {
+    "title": "et-duplicate-prop",
+    "version": "0.0.1",
+    "description":"Test case for repeated properties among entity types.",
+    "baseUri": "http://baloo/"
+  },
+  "definitions": {
+    "ETOne": {
+      "properties": {
+        "a": {
+          "datatype": "integer"
+        },
+        "b": {
+          "datatype": "string"
+        },
+        "c": {
+          "$ref": "#/definitions/ETTwo"
+        }
+      },
+      "primaryKey": "a",
+      "required": [
+        "b"
+      ],
+      "rangeIndex":["a","b","c"]
+    },
+    "ETTwo": {
+      "properties": {
+        "a": {
+          "datatype":"string"
+        }
+      },
+      "primaryKey": "a"
+    }
+  }
+}

--- a/entity-services/src/test/resources/entity-type-units/schema.xml
+++ b/entity-services/src/test/resources/entity-type-units/schema.xml
@@ -1,18 +1,18 @@
 <xs:schema elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:sem="http://marklogic.com/semantics" xmlns:es="http://marklogic.com/entity-services">
-  <xs:complexType name="ETOneContainerType" mixed="true">
-    <xs:sequence>
-      <xs:element minOccurs="0" maxOccurs="unbounded" ref="ETOne"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="ETOneType">
-    <xs:sequence>
-      <xs:element ref="a"/>
-      <xs:element ref="b"/>
-      <xs:element minOccurs="0" ref="c"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="ETOne" type="ETOneType"/>
-  <xs:element name="a" type="xs:integer"/>
-  <xs:element name="b" type="xs:string"/>
-  <xs:element name="c" type="xs:date"/>
+<xs:element name="c" type="xs:date"/>
+<xs:element name="b" type="xs:string"/>
+<xs:element name="a" type="xs:integer"/>
+<xs:complexType name="ETOneContainerType" mixed="true">
+  <xs:sequence>
+    <xs:element minOccurs="0" maxOccurs="unbounded" ref="ETOne"/>
+  </xs:sequence>
+</xs:complexType>
+<xs:complexType name="ETOneType">
+  <xs:sequence>
+    <xs:element ref="a"/>
+    <xs:element ref="b"/>
+    <xs:element minOccurs="0" ref="c"/>
+  </xs:sequence>
+</xs:complexType>
+<xs:element name="ETOne" type="ETOneType"/>
 </xs:schema>


### PR DESCRIPTION
These two commits add a fix and unit testing for the case where an entity type document has two properties of the same name.  The fix leaves the first one intact, and then detects duplicates later and emits them within comments for schema generation.
