### PR TITLE
Revert 'required' handling in database-properties

### DIFF
--- a/entity-services/src/main/xdmp/entity-services/entity-services-impl.xqy
+++ b/entity-services/src/main/xdmp/entity-services/entity-services-impl.xqy
@@ -513,10 +513,7 @@ declare function esi:database-properties-generate(
         let $datatype := esi:indexable-datatype($specified-datatype)
         let $collation := head( (map:get($property, "collation"), "http://marklogic.com/collation/en") )
         let $_ := map:put($ri-map, "collation", $collation)
-        let $invalid-values := 
-            if ($range-index-property = (map:get($entity-type-map, "primaryKey"), json:array-values(map:get($entity-type-map, "required"))))
-            then "reject"
-            else "ignore"
+        let $invalid-values := "reject"
         let $_ := map:put($ri-map, "invalid-values", $invalid-values)
         let $_ := map:put($ri-map, "path-expression", "//es:instance/" || $entity-type-name || "/" || $range-index-property)
         let $_ := map:put($ri-map, "range-value-positions", false())

--- a/entity-services/src/test/resources/entity-type-units/database-properties.json
+++ b/entity-services/src/test/resources/entity-type-units/database-properties.json
@@ -25,7 +25,7 @@
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/ETOne/c",
             "range-value-positions": false,
             "scalar-type": "date"

--- a/entity-services/src/test/resources/expected-database-properties/content-database.json
+++ b/entity-services/src/test/resources/expected-database-properties/content-database.json
@@ -17,7 +17,7 @@
     "range-path-index": [
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/arrayKey",
             "range-value-positions": false,
             "scalar-type": "long"
@@ -31,119 +31,119 @@
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/referenceInThisFile",
             "range-value-positions": false,
             "scalar-type": "string"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/arrayreferenceInThisFile",
             "range-value-positions": false,
             "scalar-type": "string"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/externalReference",
             "range-value-positions": false,
             "scalar-type": "string"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/externalArrayReference",
             "range-value-positions": false,
             "scalar-type": "string"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/byteKey",
             "range-value-positions": false,
             "scalar-type": "int"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/shortKey",
             "range-value-positions": false,
             "scalar-type": "int"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/unsignedByteKey",
             "range-value-positions": false,
             "scalar-type": "unsignedInt"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/unsignedShortKey",
             "range-value-positions": false,
             "scalar-type": "unsignedInt"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/stringKey",
             "range-value-positions": false,
             "scalar-type": "string"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/iriKey",
             "range-value-positions": false,
             "scalar-type": "string"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/anyURIKey",
             "range-value-positions": false,
             "scalar-type": "string"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/booleanKey",
             "range-value-positions": false,
             "scalar-type": "string"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/integerKey",
             "range-value-positions": false,
             "scalar-type": "decimal"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/negativeIntegerKey",
             "range-value-positions": false,
             "scalar-type": "decimal"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/nonNegativeIntegerKey",
             "range-value-positions": false,
             "scalar-type": "decimal"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/positiveIntegerKey",
             "range-value-positions": false,
             "scalar-type": "decimal"
         },
         {
             "collation": "http://marklogic.com/collation/en",
-            "invalid-values": "ignore",
+            "invalid-values": "reject",
             "path-expression": "//es:instance/SchemaCompleteEntityType/nonPositiveIntegerKey",
             "range-value-positions": false,
             "scalar-type": "decimal"


### PR DESCRIPTION
This change to the database-properties-generate() and tests reverts the handling of 'required' in this file.  We discussed this change in the WG this week, and a spec change is ready to go in that corresponds to this one.

Probably will require key changes in functional tests, s/ignore/reject/ within database-properties keys.