### PR TITLE
bug:40531 typo in search options

### DIFF
--- a/entity-services/src/main/xdmp/entity-services/entity-services-impl.xqy
+++ b/entity-services/src/main/xdmp/entity-services/entity-services-impl.xqy
@@ -1038,7 +1038,7 @@ declare function esi:search-options-generate(
             "&#10;"
         },
         <search:values name="uris">
-            <search:uris/>
+            <search:uri/>
         </search:values>,
         comment { "Change to 'filtered' to exclude false-positives in certain searches" },
         <search:search-option>unfiltered</search:search-option>,

--- a/entity-services/src/test/resources/expected-search-options/SchemaCompleteEntityType-0.0.1.xml
+++ b/entity-services/src/test/resources/expected-search-options/SchemaCompleteEntityType-0.0.1.xml
@@ -171,7 +171,7 @@
     </search:range>
   </search:tuples>
   <search:values name="uris">
-    <search:uris/>
+    <search:uri/>
   </search:values>
   <!--Uncomment to return no results for a blank search, rather than the default of all results
  <search:term xmlns:search="http://marklogic.com/appservices/search">


### PR DESCRIPTION
This fix corrects the testing bug that was skipping check-options, and also fixes the remaining issue with search:uri