### PR TITLE
Removed fail() call and added entityType in catch block so test verifySchemaValidation() runs as expected

### DIFF
--- a/entity-services-functionaltests/src/test/java/com/marklogic/entityservices/TestEsSchemaGeneration.java
+++ b/entity-services-functionaltests/src/test/java/com/marklogic/entityservices/TestEsSchemaGeneration.java
@@ -112,7 +112,7 @@ public class TestEsSchemaGeneration extends EntityServicesTestBase {
 				try{
 				DOMHandle validateResult = evalOneResult("validate strict { doc('" + testInstanceName + "') }",
 					new DOMHandle());
-				fail("Schema Validation failed.");
+				
 				InputStream is = this.getClass().getResourceAsStream("/test-instances/" + testInstanceName);
 				Document filesystemXML = builder.parse(is);
 				XMLUnit.setIgnoreWhitespace(true);
@@ -120,7 +120,7 @@ public class TestEsSchemaGeneration extends EntityServicesTestBase {
 						validateResult.get());
 				
 				}catch (TestEvalException e) {
-					throw new RuntimeException(e);
+					throw new RuntimeException("Error validating "+entityType,e);
 				}	
 			}
 			


### PR DESCRIPTION
@grechaw @rashiatmarklogic 
fail() call added to the test verifySchemaValidation() was causing the test to fail at all times. Removing ext from cleanupSchemas() took care of deleting all the schemas so a fail() call is not needed. Corrected this now and also added entityType in catch block so we know which "model" caused the test to fail.