### PR TITLE
Changing the source instances to match with the model datatype - to

### DIFF
--- a/entity-services-functionaltests/src/test/resources/source-documents/northwind/orders/10249.xml
+++ b/entity-services-functionaltests/src/test/resources/source-documents/northwind/orders/10249.xml
@@ -1,5 +1,5 @@
 <Order OrderID="10249">
-	<CustomerID>TOMSP</CustomerID>
+	<CustomerID>123</CustomerID>
 	<EmployeeID>6</EmployeeID>
 	<OrderDate>1996-07-05T06:39:18</OrderDate>
 	<RequiredDate>1996-08-16T03:39:38</RequiredDate>
@@ -15,13 +15,13 @@
 	<OrderDetails>
 		<OrderDetail>
 			<ProductID>14</ProductID>
-			<UnitPrice>18.6000</UnitPrice>
+			<UnitPrice>18</UnitPrice>
 			<Quantity>9</Quantity>
 			<Discount>0</Discount>
 		</OrderDetail>
 		<OrderDetail>
 			<ProductID>51</ProductID>
-			<UnitPrice>42.4000</UnitPrice>
+			<UnitPrice>42</UnitPrice>
 			<Quantity>40</Quantity>
 			<Discount>0</Discount>
 		</OrderDetail>

--- a/entity-services-functionaltests/src/test/resources/source-documents/northwind/products/11.xml
+++ b/entity-services-functionaltests/src/test/resources/source-documents/northwind/products/11.xml
@@ -3,7 +3,7 @@
 	<SupplierID>5</SupplierID>
 	<CategoryID>4</CategoryID>
 	<QuantityPerUnit>1 kg pkg.</QuantityPerUnit>
-	<UnitPrice>21.0000</UnitPrice>
+	<UnitPrice>21</UnitPrice>
 	<UnitsInStock>22</UnitsInStock>
 	<UnitsOnOrder>30</UnitsOnOrder>
 	<ReorderLevel>30</ReorderLevel>

--- a/entity-services-functionaltests/src/test/resources/source-documents/northwind/products/42.xml
+++ b/entity-services-functionaltests/src/test/resources/source-documents/northwind/products/42.xml
@@ -3,7 +3,7 @@
 	<SupplierID>20</SupplierID>
 	<CategoryID>5</CategoryID>
 	<QuantityPerUnit>32 - 1 kg pkgs.</QuantityPerUnit>
-	<UnitPrice>14.0000</UnitPrice>
+	<UnitPrice>14</UnitPrice>
 	<UnitsInStock>26</UnitsInStock>
 	<UnitsOnOrder>0</UnitsOnOrder>
 	<ReorderLevel>0</ReorderLevel>

--- a/entity-services-functionaltests/src/test/resources/test-envelope/valid-ref-same-document-2.xml
+++ b/entity-services-functionaltests/src/test/resources/test-envelope/valid-ref-same-document-2.xml
@@ -2,14 +2,14 @@
       <es:title>Order</es:title>
       <es:version>0.0.1</es:version>
     </es:info><Order>
-      <CustomerID>TOMSP</CustomerID>
+      <CustomerID>123</CustomerID>
       <OrderDate>1996-07-05T06:39:18</OrderDate>
       <ShipAddress>Luisenstr. 48</ShipAddress>
       <OrderDetails>
-	<OrderDetail><ProductID>14</ProductID><ProductID>51</ProductID><UnitPrice>18.6000</UnitPrice><UnitPrice>42.4000</UnitPrice><Quantity>9</Quantity><Quantity>40</Quantity></OrderDetail>
+	<OrderDetail><ProductID>14</ProductID><ProductID>51</ProductID><UnitPrice>18</UnitPrice><UnitPrice>42</UnitPrice><Quantity>9</Quantity><Quantity>40</Quantity></OrderDetail>
       </OrderDetails>
     </Order></es:instance><es:attachments><Order OrderID="10249">
-      <CustomerID>TOMSP</CustomerID>
+      <CustomerID>123</CustomerID>
       <EmployeeID>6</EmployeeID>
       <OrderDate>1996-07-05T06:39:18</OrderDate>
       <RequiredDate>1996-08-16T03:39:38</RequiredDate>
@@ -25,13 +25,13 @@
       <OrderDetails>
 	<OrderDetail>
 			<ProductID>14</ProductID>
-			<UnitPrice>18.6000</UnitPrice>
+			<UnitPrice>18</UnitPrice>
 			<Quantity>9</Quantity>
 			<Discount>0</Discount>
 		</OrderDetail>
 	<OrderDetail>
 			<ProductID>51</ProductID>
-			<UnitPrice>42.4000</UnitPrice>
+			<UnitPrice>42</UnitPrice>
 			<Quantity>40</Quantity>
 			<Discount>0</Discount>
 		</OrderDetail>

--- a/entity-services-functionaltests/src/test/resources/test-extract-instance/instance-Product.json
+++ b/entity-services-functionaltests/src/test/resources/test-extract-instance/instance-Product.json
@@ -1,8 +1,8 @@
 {
 "$type": "Product", 
-"$attachments": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Product ProductID=\"11\">\n\t<ProductName>Queso Cabrales</ProductName>\n\t<SupplierID>5</SupplierID>\n\t<CategoryID>4</CategoryID>\n\t<QuantityPerUnit>1 kg pkg.</QuantityPerUnit>\n\t<UnitPrice>21.0000</UnitPrice>\n\t<UnitsInStock>22</UnitsInStock>\n\t<UnitsOnOrder>30</UnitsOnOrder>\n\t<ReorderLevel>30</ReorderLevel>\n\t<Discontinued>false</Discontinued>\n</Product>", 
+"$attachments": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Product ProductID=\"11\">\n\t<ProductName>Queso Cabrales</ProductName>\n\t<SupplierID>5</SupplierID>\n\t<CategoryID>4</CategoryID>\n\t<QuantityPerUnit>1 kg pkg.</QuantityPerUnit>\n\t<UnitPrice>21</UnitPrice>\n\t<UnitsInStock>22</UnitsInStock>\n\t<UnitsOnOrder>30</UnitsOnOrder>\n\t<ReorderLevel>30</ReorderLevel>\n\t<Discontinued>false</Discontinued>\n</Product>", 
 "ProductName": "Queso Cabrales", 
-"UnitPrice": "21.0000", 
+"UnitPrice": "21", 
 "SupplierID": "5", 
 "Discontinued": "false"
 }

--- a/entity-services-functionaltests/src/test/resources/test-extract-instance/instance-Product2.json
+++ b/entity-services-functionaltests/src/test/resources/test-extract-instance/instance-Product2.json
@@ -1,8 +1,8 @@
 {
 "$type": "Product", 
-"$attachments": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Product ProductID=\"42\">\n\t<ProductName>Singaporean Hokkien Fried Mee</ProductName>\n\t<SupplierID>20</SupplierID>\n\t<CategoryID>5</CategoryID>\n\t<QuantityPerUnit>32 - 1 kg pkgs.</QuantityPerUnit>\n\t<UnitPrice>14.0000</UnitPrice>\n\t<UnitsInStock>26</UnitsInStock>\n\t<UnitsOnOrder>0</UnitsOnOrder>\n\t<ReorderLevel>0</ReorderLevel>\n\t<Discontinued>true</Discontinued>\n</Product>", 
+"$attachments": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Product ProductID=\"42\">\n\t<ProductName>Singaporean Hokkien Fried Mee</ProductName>\n\t<SupplierID>20</SupplierID>\n\t<CategoryID>5</CategoryID>\n\t<QuantityPerUnit>32 - 1 kg pkgs.</QuantityPerUnit>\n\t<UnitPrice>14</UnitPrice>\n\t<UnitsInStock>26</UnitsInStock>\n\t<UnitsOnOrder>0</UnitsOnOrder>\n\t<ReorderLevel>0</ReorderLevel>\n\t<Discontinued>true</Discontinued>\n</Product>", 
 "ProductName": "Singaporean Hokkien Fried Mee", 
-"UnitPrice": "14.0000", 
+"UnitPrice": "14", 
 "SupplierID": "20", 
 "Discontinued": "true"
 }


### PR DESCRIPTION
avoid XDMP-CAST error. But, now hitting some other problems. The test
TestEsConversionModuleGenerator.java still will fail in regression but
atleast not with XDMP-CAST error.

Hi, @bsrikan @grechaw Please merge this PR to develop. TestEsConversionModuleGenerate.java will still fail but avoiding XDMP-CAST error with this PR. 