### PR TITLE
Convert instance rework

### DIFF
--- a/entity-services/src/main/xdmp/entity-services/entity-services-codegen.xqy
+++ b/entity-services/src/main/xdmp/entity-services/entity-services-codegen.xqy
@@ -387,7 +387,7 @@ declare private function es-codegen:value-for-conversion(
         then $source-entity-type=>map:get("properties")
         else ()
     let $is-missing-source :=
-        (exists($source-properties) and ($target-property-name = map:keys($source-properties)))
+        (exists($source-properties) and not($target-property-name = map:keys($source-properties)))
     let $source-correlate :=
         if (exists($source-properties))
         then map:get($source-properties, $target-property-name)
@@ -539,7 +539,7 @@ declare function es-codegen:version-translator-generate(
  :)
 { if (not($entity-type-name = map:keys($source-definitions)))
     then "
-(: Type " || $entity-type-name || "is not in the source model.
+(: Type " || $entity-type-name || " is not in the source model.
  : XPath expressions are created as though there were no change between source and target type.
  :)"
     else () }

--- a/entity-services/src/test/java/com/marklogic/entityservices/tests/TestVersionTranslator.java
+++ b/entity-services/src/test/java/com/marklogic/entityservices/tests/TestVersionTranslator.java
@@ -72,11 +72,18 @@ public class TestVersionTranslator extends EntityServicesTestBase {
 
         DOMHandle domHandle = evalOneResult(
             "import module namespace c = 'http://example.org/tests/conversion-0.0.2-from-conversion-0.0.1' at '/ext/version-converter.xqy';" +
-            "import module namespace m = 'http://example.org/tests/conversion-0.0.2' at '/ext/comparison-0.0.2.xqy';", "<x>{" +
-                "doc('instance-0.0.1.xml')/x=>c:convert-instance-ETOne()=>m:instance-to-canonical-xml()," +
-                "doc('instance-0.0.1.xml')/x=>c:convert-instance-ETTwo()=>m:instance-to-canonical-xml()," +
-                "doc('instance-0.0.1.xml')/x=>c:convert-instance-ETThree()=>m:instance-to-canonical-xml()" +
-                "}</x>",
+            "import module namespace m = 'http://example.org/tests/conversion-0.0.2' at '/ext/comparison-0.0.2.xqy';",
+            "<x xmlns:es=\"http://marklogic.com/entity-services\">" +
+                "<es:instance>{" +
+                "doc('instance-0.0.1.xml')=>c:convert-instance-ETOne()=>m:instance-to-canonical-xml()" +
+                "}</es:instance>" +
+                "<es:instance>{" +
+                "doc('instance-0.0.1.xml')=>c:convert-instance-ETTwo()=>m:instance-to-canonical-xml()" +
+                "}</es:instance>" +
+                "<es:instance>{" +
+                "doc('instance-0.0.1.xml')=>c:convert-instance-ETThree()=>m:instance-to-canonical-xml()" +
+                "}</es:instance>" +
+                "</x>",
             new DOMHandle());
 
         String expected = "instance-0.0.2.xml";

--- a/entity-services/src/test/resources/model-units/instance-0.0.1.xml
+++ b/entity-services/src/test/resources/model-units/instance-0.0.1.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<x>
+<x xmlns:es="http://marklogic.com/entity-services">
+<es:instance>
   <ETOne>
     <pk>http://example.org/some-iri/1</pk>
     <p1>1</p1>
@@ -13,6 +14,8 @@
     <p6>4</p6>
     <p6>4</p6>
   </ETOne>
+  </es:instance>
+  <es:instance>
   <ETTwo>
     <pk>http://example.org/some-iri/2</pk>
     <parent>
@@ -36,4 +39,5 @@
   <ETFour>
     <p1>100293</p1>
   </ETFour>
+</es:instance>
 </x>

--- a/entity-services/src/test/resources/model-units/instance-0.0.2.xml
+++ b/entity-services/src/test/resources/model-units/instance-0.0.2.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<x>
+<x xmlns:es="http://marklogic.com/entity-services">
+  <es:instance>
   <ETOne>
     <pk>http://example.org/some-iri/1</pk>
     <p1>1</p1>
@@ -9,6 +10,8 @@
     <p5>12</p5>
     <p6>4</p6>
   </ETOne>
+  </es:instance>
+  <es:instance>
   <ETTwo>
     <pk>http://example.org/some-iri/2</pk>
     <parent><ETOne>http://example.org/some-iri</ETOne></parent>
@@ -20,6 +23,8 @@
     <p10/>
     <p12>100293</p12>
     <p13 datatype="array">100293</p13>
-  </ETTwo>
+  </ETTwo></es:instance>
+  <es:instance>
   <ETThree/>
+  </es:instance>
 </x>


### PR DESCRIPTION
This PR fixes remaining issues with convert-instance in #183 .

It also explicitly changes some test cases to work with nodes that look more like canonical instance documents.  <es:intance> wrapped.

So this change may require some key updates.  I think it's the right thing to do but would like input.  The tests as written in this PR are all passing green.