### PR TITLE
Bugfixes

### DIFF
--- a/entity-services-examples/gradle.properties
+++ b/entity-services-examples/gradle.properties
@@ -1,8 +1,16 @@
-mlAppName=entity-services-examples
+# note the following properties and change as required.
+# these defaults assume a fresh system running on your
+# local computer, which you secured with admin/admin credentials
+# (essentially, no security)
 mlHost=localhost
 mlAdminUsername=admin
 mlAdminPassword=admin
+mlManageUsername=admin
+mlManagePassword=admin
+mlRestAdminUsername=admin
+mlRestAdminPassword=admin
 mlModulePermissions=rest-admin,read,rest-admin,update,rest-extension-user,execute,rest-reader,read,race-reader,execute
 mlRestPort=8203
+mlAppName=entity-services-examples
 mlModulesDatabaseName=entity-services-examples-modules
 mlSchemasDatabaseName=entity-services-examples-schemas

--- a/entity-services/src/main/xdmp/entity-services/entity-services-impl.xqy
+++ b/entity-services/src/main/xdmp/entity-services/entity-services-impl.xqy
@@ -91,7 +91,7 @@ declare private variable $esi:model-schematron :=
           <iso:assert test="not(local-name(.) = root(.)/es:model/es:definitions/*/local-name(.))" id="ES-PROPERTY-TYPE-CONFLICT">Type names and property names must be distinct ('<xsl:value-of select="xs:string(node-name(.))"/>')</iso:assert>
         </iso:rule>
         <iso:rule context="es:ref|node('$ref')">
-          <iso:assert test="starts-with(xs:string(.),'#/definitions/') or matches(xs:string(.), '^[a-x]+:')" id="ES-REF-VALUE">es:ref (property '<xsl:value-of select="xs:string(node-name(.))"/>') must start with "#/definitions/" or be an absolute IRI.</iso:assert>
+          <iso:assert test="starts-with(xs:string(.),'#/definitions/') or matches(xs:string(.), '^[a-z]+:')" id="ES-REF-VALUE">es:ref (property '<xsl:value-of select="xs:string(node-name(.))"/>') must start with "#/definitions/" or be an absolute IRI.</iso:assert>
           <iso:assert test="replace(xs:string(.), '.*/', '') castable as xs:NCName" id="ES-REF-VALUE"><xsl:value-of select="."/>: ref value must end with a simple name (xs:NCName).</iso:assert>
           <iso:assert test="if (starts-with(xs:string(.), '#/definitions/')) then replace(xs:string(.), '#/definitions/', '') = (root(.)/definitions/*/node-name(.) ! xs:string(.), root(.)/es:model/es:definitions/*/local-name(.)) else true()" id="ES-LOCAL-REF">Local reference <xsl:value-of select="."/> must resolve to local entity type.</iso:assert>
           <iso:assert test="if (not(contains(xs:string(.), '#/definitions/'))) then matches(xs:string(.), '^[a-z]+:') else true()" id="ES-ABSOLUTE-REF">Non-local reference <xsl:value-of select="."/> must be a valid URI.</iso:assert>

--- a/entity-services/src/main/xdmp/entity-services/entity-services-instance.xqy
+++ b/entity-services/src/main/xdmp/entity-services/entity-services-instance.xqy
@@ -95,7 +95,9 @@ declare function inst:instance-json-from-document(
 
 declare function inst:instance-get-attachments(
     $document as document-node()
-) as element()*
+) as item()*
 {
-    $document//es:attachments/*
+    if (exists($document//es:attachments/*))
+    then $document//es:attachments/*
+    else $document//es:attachments/text()
 };

--- a/entity-services/src/main/xdmp/entity-services/entity-services.xqy
+++ b/entity-services/src/main/xdmp/entity-services/entity-services.xqy
@@ -237,7 +237,7 @@ declare function es:instance-json-from-document(
  :)
 declare function es:instance-get-attachments(
     $document as document-node()
-) as element()*
+) as item()*
 {
     inst:instance-get-attachments($document)
 };

--- a/entity-services/src/test/java/com/marklogic/entityservices/tests/TestInstanceConverterGenerator.java
+++ b/entity-services/src/test/java/com/marklogic/entityservices/tests/TestInstanceConverterGenerator.java
@@ -27,6 +27,8 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
+import com.jayway.restassured.internal.path.json.JSONAssertion;
+import com.marklogic.client.document.XMLDocumentManager;
 import com.marklogic.client.io.*;
 import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
@@ -261,6 +263,23 @@ public class TestInstanceConverterGenerator extends EntityServicesTestBase {
         }
     }
 
+    @Test
+    public void testJsonAttachments()
+    {
+        InputStream testEnvelope = this.getClass().getResourceAsStream("/model-units/test-envelope-json-attachment.xml");
+        XMLDocumentManager xmlDocMgr = client.newXMLDocumentManager();
+        xmlDocMgr.write("/test-envelope-json-attachment.xml", new InputStreamHandle(testEnvelope).withFormat(Format.XML));
+
+        StringHandle stringHandle = evalOneResult("",
+            "es:instance-get-attachments( doc('/test-envelope-json-attachment.xml') )",
+            new StringHandle());
+
+        String actual = stringHandle.get();
+
+        assertEquals("{\"bah\":\"yes\"}", actual);
+
+        xmlDocMgr.delete("/test-envelope-json-attachment.xml");
+    }
 
     @Test
     public void testEnvelopeFunction() throws TestEvalException {


### PR DESCRIPTION
This small change accommodates issue #207.

Note that it is a minor interface change, as getting back JSON (I chose as text, let's discuss) required es:get-attachments to return item()* rather than element()*, which I think is appropriate. 

This PR has had two more fixes added to it.  Issues #221, which improves the convert-instance generation, and #198 which is a pretty lousy bug to have go out the door.  Come to think of it, @mmalgeri was subject to the same bug... it will hit anyone who doesn't have brain-dead security on their examples server.