### PR TITLE
Example fixes issues #230, eliminates long pause for person example

### DIFF
--- a/entity-services-examples/src/main/java/com/marklogic/entityservices/examples/ExamplesBase.java
+++ b/entity-services-examples/src/main/java/com/marklogic/entityservices/examples/ExamplesBase.java
@@ -94,8 +94,6 @@ public abstract class ExamplesBase {
                     // throwable.printStackTrace();
                 });
 
-        moveMgr.startJob(batcher);
-
         return batcher;
     }
 
@@ -139,6 +137,7 @@ public abstract class ExamplesBase {
 
         importOrDescend(referenceDataDir, batcher, collection, Format.TEXT);
 
+        moveMgr.startJob(batcher);
         batcher.flushAsync();
     }
 
@@ -153,6 +152,7 @@ public abstract class ExamplesBase {
         WriteBatcher batcher = newBatcher();
         importOrDescend(jsonDirectory, batcher, toCollection, Format.JSON);
 
+        moveMgr.startJob(batcher);
         batcher.flushAsync();
     }
 
@@ -164,6 +164,7 @@ public abstract class ExamplesBase {
 
         importOrDescend(xmlDirectory, batcher, toCollection, Format.XML);
 
+        moveMgr.startJob(batcher);
         batcher.flushAsync();
     }
 

--- a/entity-services-examples/src/main/java/com/marklogic/entityservices/examples/person/PersonExplorer.java
+++ b/entity-services-examples/src/main/java/com/marklogic/entityservices/examples/person/PersonExplorer.java
@@ -151,7 +151,7 @@ public class PersonExplorer extends ExamplesBase {
                 });
 
         JobTicket ticket = moveMgr.startJob(queryBatcher);
-        queryBatcher.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
+        queryBatcher.awaitCompletion();
         moveMgr.stopJob(ticket);
     }
 

--- a/entity-services-examples/src/main/java/com/marklogic/entityservices/examples/race/Harmonizer.java
+++ b/entity-services-examples/src/main/java/com/marklogic/entityservices/examples/race/Harmonizer.java
@@ -55,7 +55,7 @@ public class Harmonizer extends ExamplesBase {
                 });
 
         JobTicket ticket = moveMgr.startJob(queryBatcher);
-        queryBatcher.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
+        queryBatcher.awaitCompletion();
         moveMgr.stopJob(ticket);
     }
 
@@ -82,7 +82,7 @@ public class Harmonizer extends ExamplesBase {
                 });
 
         JobTicket ticket = moveMgr.startJob(queryBatcher);
-        queryBatcher.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
+        queryBatcher.awaitCompletion();
         moveMgr.stopJob(ticket);
     }
 


### PR DESCRIPTION
This change is straightforward and fixes issues with how I was using DMSDK in my example code.

One of the changes caused a failure -- so this PR fixes #230 .

@jmakeig or @rashiatmarklogic  can you take a peek at this before I merge to develop?